### PR TITLE
Use decodeBytes instead of decodeUriComponent.

### DIFF
--- a/component/suites/test.jsx
+++ b/component/suites/test.jsx
@@ -9,13 +9,28 @@ let knownStatuses = [
   'skip'
 ]
 
+function hex2a(hexx) {
+  const hex = hexx.toString();
+  let str = '';
+
+  for (var i = 0; (i < hex.length && hex.substr(i, 2) !== '00'); i += 2) {
+    str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+  }
+
+  return str;
+}
+
+function decodeBytes(message) {
+  return message.replace(/%\d\d/g, (s, m) => hex2a(m))
+}
+
 let Test = ({uuid, status, name, message, raw, onToggle, collapsed, onToggleRaw, time}) => {
   let isCollapsed = Object.keys(collapsed.tests).includes(uuid) ? 'collapsed' : 'expanded'
   status = knownStatuses.includes(status) ? status : 'unknown'
   let Content = null
 
-  if (raw) Content = <code className='test-code'>{decodeURIComponent(message)}</code>
-  else if (message) Content = <div className='test-message' dangerouslySetInnerHTML={{__html: decodeURIComponent(message)}} />
+  if (raw) Content = <code className='test-code'>{decodeBytes(message)}</code>
+  else if (message) Content = <div className='test-message' dangerouslySetInnerHTML={{__html: decodeBytes(message)}} />
 
   return <div className={`card test is-${isCollapsed}`}>
     <header


### PR DESCRIPTION
Unfortunately using the decodeUriComponent fails in some scenarios, when strings are somehow not valid URI components (such as Java stack traces).