### PR TITLE
docs: add inner-workings doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # IDEs
 .idea
+.vscode
 
 # dependencies
 /node_modules
@@ -25,3 +26,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+src/**/*.xml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Roadmap
+
+* Fail-first sorting, i.e. ability to view failed tests at the top
+* Opinionated config UX instead of 8x3 grid of switches/checkboxes. Make config tweak behaviour more intuitive (e.g. hide items completely if user chooses to hide them)
+  * Also make config component accessible from every scroll position, so that user doesn't have to scroll to the top to access it
+* Maybe: sidebar with the ability to preview and leap to a test suite, to add the ability to quickly navigate the document
+
 # Xunit Viewer
 
 Takes all your XUnit and JUnit XML files and makes them readable

--- a/docs/inner-workings.md
+++ b/docs/inner-workings.md
@@ -1,0 +1,72 @@
+# xunit-viewer
+
+
+## Front end
+
+Powered by **Create React App**.
+
+```mermaid
+graph LR;
+    *.js--> CRA;
+    *.css--> CRA;
+    CRA==> cli/static/;
+```
+
+Frontend is a React app based at [src/app/app.js](/src/app/app.js)
+
+To be used from CLI, it's built by CRA and build output is saved in [`src/cli/static/`](src/cli/static/) directory (and commited into git without `index.html` file).
+
+## CLI
+
+Command line program is a Node.js file that handles command line options and outputs the Xunit html file to disk, among other things.
+
+```mermaid
+graph LR;
+    subgraph static
+    statis/*.js;
+    static/*.css;
+    end
+
+    subgraph user input
+    junit.xml
+    end
+
+    statis/*.js -->|require| CLI;
+    static/*.css-->|require| CLI;
+
+    template["Handlebars template"]--> CLI;
+    
+    junit.xml--> CLI;
+
+    CLI--> Handlebars;
+
+    Handlebars==> index.html["index.html – <i>output</i>"];
+
+```
+
+As you see, to make changes on the frontend, you have to make changes to React app, build it, then run CLI to output a new html file. And that's how you commit changes to the CLI.
+
+In order to quickly test in development you need to import a sample junit file in [`index.js`](/src/index.js). Like this:
+
+```diff
++import sampleXml from './path/to/sample.xml'
+
+if (process.env.NODE_ENV === 'development') {
+  files = [{
+    file: '/path/to/file/complete.xml',
+    contents: LZUTF8.compress(`
+-    <?xml version="1.0" encoding="UTF-8"?>
+-<testsuite tests="1" failures="1" time="0.0160106">
+-  <testcase name="It Is A Failure" classname="Failing" time="0.012011200000000001">
+-    <error>Error message</error>
+-    <system-out>Some messgae</system-out>
+-    <failure type="Failure">FILENAME:XX</failure>
+-  </testcase>
+-</testsuite>
++${sampleXml}
+`, { outputEncoding: 'Base64' })
+  }]
+}
+```
+
+Where `sampleXml` is a string with contents of Junit XML file. You can import it, you can hardcode it, any means you see necessary. But before commiting you have to ensure that this change is not staged, so it won't get commited to `master` branch.

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -91,6 +91,7 @@ const App = ({ files, title, brand }) => {
           total={propertiesTotal}
           dispatch={dispatch}
         />
+        {/* TODO: figure out what this does in development */}
         {process.env.NODE_ENV === 'development'
           ? <Files files={files} active={state.activeFiles} setActive={() => { dispatch({ type: 'toggle-files' }) }} />
           : null}


### PR DESCRIPTION
describe how the app is architected and how to make changes to the frontend

README: add Roadmap with UX changes that I want to bring in

.gitignore: add .vscode dir and xml files in src (used for dev testing)

<img width="964" alt="Screenshot 2022-11-26 at 14 55 47" src="https://user-images.githubusercontent.com/8898635/204090056-c8e24852-483e-4cd1-878b-17410a230439.png">
