### PR TITLE
TypeError: files is not iterable

### DIFF
--- a/src/cli/server.js
+++ b/src/cli/server.js
@@ -15,7 +15,7 @@ export default async (logger, args) => {
   const io = new Server(http)
 
   app.get('/', async (req, res) => {
-    const files = getFiles(logger, args)
+    const files = await getFiles(logger, args)
     const suites = await getSuites(logger, files)
     const description = getDescription(suites)
 


### PR DESCRIPTION
xunit-viewer -p 9202 -r "/opt/goss/" -s
Written to: /tmp/node-v20.6.1-linux-x64/bin/index.html
Listening at http://10.xxx.xxx.xx:9202
file:///usr/local/lib/node_modules/xunit-viewer/src/cli/get-suites.js:9
  for (const { file, contents } of files) {
                                   ^

TypeError: files is not iterable
    at default (file:///usr/local/lib/node_modules/xunit-viewer/src/cli/get-suites.js:9:36)
    at file:///usr/local/lib/node_modules/xunit-viewer/src/cli/server.js:19:26
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/router/route.js:144:13)
    at Route.dispatch (/usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/router/route.js:114:3)
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/router/layer.js:95:5)
    at /usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/router/index.js:346:12)
    at next (/usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/router/index.js:280:10)
    at expressInit (/usr/local/lib/node_modules/xunit-viewer/node_modules/express/lib/middleware/init.js:40:5)

Node.js v20.6.1
